### PR TITLE
Move Module Cypress Tests above (all) Cypress Tests

### DIFF
--- a/.github/workflows/module-plugin-test.yml
+++ b/.github/workflows/module-plugin-test.yml
@@ -211,11 +211,11 @@ jobs:
         run: npx @wordpress/env@latest start
 
       - name: Run Module Cypress Tests
-        run: npm run test:e2e -- --browser chrome --spec "vendor/${{ inputs.module-repo }}/**/*"
+        run: npm run test:e2e -- --browser chrome --spec "vendor/(${{ inputs.module-repo }}/**/*.cy.js)"
 
       - name: Run Remaining Cypress Tests
         if: ${{ ! inputs.only-module-tests }}
-        run: npm run test:e2e -- --browser chrome --spec "vendor/!(${{ inputs.module-repo }})"
+        run: npm run test:e2e -- --browser chrome --spec "vendor/!(${{ inputs.module-repo }}/**/*.cy.js)"
 
       - name: Store screenshots of test failures
         if: failure()

--- a/.github/workflows/module-plugin-test.yml
+++ b/.github/workflows/module-plugin-test.yml
@@ -210,13 +210,12 @@ jobs:
       - name: Install WordPress
         run: npx @wordpress/env@latest start
 
-      - name: Run Only Module Cypress Tests
-        if: ${{ inputs.only-module-tests }}
+      - name: Run Module Cypress Tests
         run: npm run test:e2e -- --browser chrome --spec "vendor/${{ inputs.module-repo }}/**/*"
 
-      - name: Run Cypress Tests
+      - name: Run Remaining Cypress Tests
         if: ${{ ! inputs.only-module-tests }}
-        run: npm run test:e2e -- --browser chrome
+        run: npm run test:e2e -- --browser chrome --spec "vendor/!(${{ inputs.module-repo }})"
 
       - name: Store screenshots of test failures
         if: failure()

--- a/.github/workflows/module-plugin-test.yml
+++ b/.github/workflows/module-plugin-test.yml
@@ -210,13 +210,13 @@ jobs:
       - name: Install WordPress
         run: npx @wordpress/env@latest start
 
-      - name: Run Cypress Tests
-        if: ${{ ! inputs.only-module-tests }}
-        run: npm run test:e2e -- --browser chrome
-
       - name: Run Only Module Cypress Tests
         if: ${{ inputs.only-module-tests }}
         run: npm run test:e2e -- --browser chrome --spec "vendor/${{ inputs.module-repo }}/**/*"
+
+      - name: Run Cypress Tests
+        if: ${{ ! inputs.only-module-tests }}
+        run: npm run test:e2e -- --browser chrome
 
       - name: Store screenshots of test failures
         if: failure()


### PR DESCRIPTION
When tests run in a module's repo, we're most interested to known if the tests _for that module_ are passing or not.

This PR reorders the test so module-specific tests are run first.

See in the screenshot, it's impossible to know if the tests that failed are related to the code in this repo or a failure caused by a problem elsewhere.

<img width="498" alt="Screenshot 2024-01-31 at 5 06 43 PM" src="https://github.com/newfold-labs/workflows/assets/4720401/ad7af8a8-5453-4c8d-b016-dd8e713e45e7">
