### PR TITLE
Add missing trailing slash in rsync command

### DIFF
--- a/.github/workflows/module-plugin-test.yml
+++ b/.github/workflows/module-plugin-test.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Sync Module build files to node_modules dir
         if: ${{ inputs.sync-npm-package }}
-        run: rsync -r -v -h --progress vendor/${{ inputs.module-repo }}/build node_modules/@${{ inputs.module-repo }}/build
+        run: rsync -r -v -h "vendor/${{ inputs.module-repo }}/build/" "node_modules/@${{ inputs.module-repo }}/build"
 
       - name: Build Plugin
         run: npm run build


### PR DESCRIPTION
## Proposed changes

The rsync command was missing the trailing slash so it wasn't properly copying build files into the npm dir. This should fix that and the module test workflow will reflect branch changes in js too now.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
