### PR TITLE
Add `if:` condition to search for `*.cy*` before attempting to run them

### DIFF
--- a/.github/workflows/module-plugin-test.yml
+++ b/.github/workflows/module-plugin-test.yml
@@ -229,6 +229,7 @@ jobs:
         run: npx @wordpress/env@latest start --debug
 
       - name: Run Module Cypress Tests
+        if: $([[ ! $(find ./vendor/${{ inputs.module-repo }} -depth -name '*.cy*') ]])
         run: npm run test:e2e -- --browser chrome --spec "vendor/(${{ inputs.module-repo }}/**/*.cy.js)"
 
       - name: Run Remaining Cypress Tests


### PR DESCRIPTION
## Proposed changes

Module workflows are failing when the modules have no Cypress tests to run.

See: https://github.com/newfold-labs/wp-module-data/actions/runs/9006556236/job/24744362247?pr=72

I.e. `npm run test:e2e -- --browser chrome --spec "vendor/(newfold-labs/wp-module-data/**/*.cy.js)"` fails.

```
Can't run because no spec files were found.

We searched for specs matching this glob pattern:

  > /home/runner/work/wp-module-data/wp-module-data/vendor/(newfold-labs/wp-module-data/**/*.cy.js)
Error: Process completed with exit code 1.
```

Note: Are those brackets correct? That's how it is in the workflow currently.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc

## Further comments

In a plugin, run:
```
$([[ ! $(find ./vendor/newfold-labs/wp-module-coming-soon -depth -name '*.cy*') ]])
echo $?     
```
and observe the output is
```
1
```

Run
```
$([[ ! $(find ./vendor/newfold-labs/wp-module-data -depth -name '*.cy*') ]])
echo $?     
```
and observe the output is
```
0
```

I think this should be enough to fix this, although GitHub Actions might not like the expression being evaluated where it is and it might need to be moved to its own step and write to a variable first.

**Another solution** would be to add [`continue-on-error: true`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error)
