### PR TITLE
In its own step, determine if no module Cypress tests found

### DIFF
--- a/.github/workflows/module-plugin-test.yml
+++ b/.github/workflows/module-plugin-test.yml
@@ -228,8 +228,15 @@ jobs:
       - name: Install WordPress
         run: npx @wordpress/env@latest start --debug
 
+      - name: Check for module tests
+        id: check-for-module-tests
+        run:
+          if [[ $(find ./vendor/${{ inputs.module-repo }} -depth -name '*.cy*') ]]; then MODULE_TESTS_FOUND=1; else MODULE_TESTS_FOUND=0; fi
+          if [[ $MODULE_TESTS_FOUND -eq 0 ]]; then echo "No module Cypress tests found"; fi
+          echo "MODULE_TESTS_FOUND=$MODULE_TESTS_FOUND" >> $GITHUB_OUTPUT;
+
       - name: Run Module Cypress Tests
-        if: $([[ ! $(find ./vendor/${{ inputs.module-repo }} -depth -name '*.cy*') ]])
+        if: ${{ steps.check-for-module-tests.outputs.MODULE_TESTS_FOUND }}
         run: npm run test:e2e -- --browser chrome --spec "vendor/(${{ inputs.module-repo }}/**/*.cy.js)"
 
       - name: Run Remaining Cypress Tests


### PR DESCRIPTION
## Proposed changes

Earlier attempt to skip Cypress tests when none exist didn't seem to work.

This moves the logic to its own step and uses the output of that step in the conditional of the actual tests step.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

