### PR TITLE
Centralizing i18n Crowdin Workflows

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -1,5 +1,5 @@
 # Instructions for Using the Translation Workflow:
-# Detailed guidelines for utilizing the translation workflow can be found in Section 5.12 
+# Detailed guidelines for utilizing the translation workflow can be found in Section 5.12
 # of our documentation: [How We Work](https://newfold-labs.github.io/how-we-work/5.12-crowdin-translation-workflow.html).
 
 name: Crowdin Download Action
@@ -22,8 +22,8 @@ on:
         required: true
 
 permissions:
-  contents: write        
-  pull-requests: write   
+  contents: write
+  pull-requests: write
 
 jobs:
   synchronize-with-crowdin:
@@ -49,7 +49,7 @@ jobs:
         env:
           # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
           # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
           CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
 

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -1,0 +1,57 @@
+# Instructions for Using the Translation Workflow:
+# Detailed guidelines for utilizing the translation workflow can be found in Section 5.12 
+# of our documentation: [How We Work](https://newfold-labs.github.io/how-we-work/5.12-crowdin-translation-workflow.html).
+
+name: Crowdin Download Action
+
+on:
+  workflow_call:
+    inputs:
+      base_branch:
+        description: 'Base branch for the pull request'
+        required: false
+        default: 'main'
+        type: string
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      CROWDIN_PERSONAL_TOKEN:
+        required: true
+    vars:
+      CROWDIN_PROJECT_ID:
+        required: true
+
+permissions:
+  contents: write        
+  pull-requests: write   
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: crowdin action
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n_crowdin_translations
+          create_pull_request: true
+          auto_approve_imported: true
+          pull_request_title: 'New Crowdin Translations'
+          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          pull_request_base_branch_name: ${{ inputs.base_branch }}
+
+        env:
+          # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+
+          # Visit https://crowdin.com/settings#api-key to create this token
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -1,5 +1,5 @@
 # Instructions for Using the Translation Workflow:
-# Detailed guidelines for utilizing the translation workflow can be found in Section 5.12 
+# Detailed guidelines for utilizing the translation workflow can be found in Section 5.12
 # of our documentation: [How We Work](https://newfold-labs.github.io/how-we-work/5.12-crowdin-translation-workflow.html).
 
 name: Crowdin Upload Action
@@ -16,8 +16,8 @@ on:
         required: true
 
 permissions:
-  contents: write        
-  pull-requests: write   
+  contents: write
+  pull-requests: write
 
 jobs:
   synchronize-with-crowdin:
@@ -35,7 +35,7 @@ jobs:
           download_translations: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
           # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
           CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
 

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -1,0 +1,43 @@
+# Instructions for Using the Translation Workflow:
+# Detailed guidelines for utilizing the translation workflow can be found in Section 5.12 
+# of our documentation: [How We Work](https://newfold-labs.github.io/how-we-work/5.12-crowdin-translation-workflow.html).
+
+name: Crowdin Upload Action
+
+on:
+  workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      CROWDIN_PERSONAL_TOKEN:
+        required: true
+    vars:
+      CROWDIN_PROJECT_ID:
+        required: true
+
+permissions:
+  contents: write        
+  pull-requests: write   
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: crowdin action
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: true
+          download_translations: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+
+          # Visit https://crowdin.com/settings#api-key to create this token
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
## Proposed changes

This PR centralizes the Crowdin translation workflows (Upload & Download Actions) into the newfold-labs/workflows repository. This allows all repositories to reuse these workflows instead of maintaining separate copies.

Changes Made

- [x] Added .github/workflows/i18n-crowdin-download.yml for downloading translations from Crowdin.
- [x] Added .github/workflows/i18n-crowdin-upload.yml for uploading sources and translations to Crowdin.
- [x] Configured workflows to support workflow_call, allowing other repositories to invoke them.