### PR TITLE
Change Github Access Token in the Crowdin Download Workflow

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -46,7 +46,7 @@ jobs:
 
         env:
           # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NEWFOLD_ACCESS_TOKEN }}
 
           # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
           CROWDIN_PROJECT_ID: ${{ inputs.CROWDIN_PROJECT_ID }}


### PR DESCRIPTION
## Proposed changes

This PR changes Github Access Token in the Crowdin Download Workflow.