### PR TITLE
Add codecoverage cleanup

### DIFF
--- a/.github/workflows/example-codecoverage-cleanup.yml
+++ b/.github/workflows/example-codecoverage-cleanup.yml
@@ -7,6 +7,8 @@
 # Prerequisites:
 #   - Your repo uses newfold-labs/workflows reusable-codecoverage and has a gh-pages branch.
 #   - No need to pass repo_token unless you use a different token for gh-pages; GITHUB_TOKEN is used by default.
+#
+# For stricter code scanning (pinned refs), replace @main with a commit SHA from newfold-labs/workflows.
 ##
 name: Code Coverage Cleanup (example)
 
@@ -18,10 +20,7 @@ on:
     # Weekly on Sunday at 00:00 UTC
     - cron: '0 0 * * 0'
 
-permissions:
-  contents: write
-  pull-requests: read
-
+# Permissions set per-job to avoid overly broad write at workflow level.
 jobs:
   get-merged-pr-commits:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
@@ -42,6 +41,8 @@ jobs:
   cleanup-on-merge:
     needs: get-merged-pr-commits
     if: always() && needs.get-merged-pr-commits.result == 'success'
+    permissions:
+      contents: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
     with:
       shas: ${{ needs.get-merged-pr-commits.outputs.shas }}
@@ -51,6 +52,8 @@ jobs:
 
   cleanup-on-branch-delete:
     if: github.event_name == 'delete' && github.event.ref_type == 'branch'
+    permissions:
+      contents: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
     with:
       shas: ''
@@ -60,6 +63,8 @@ jobs:
 
   cleanup-scheduled:
     if: github.event_name == 'schedule'
+    permissions:
+      contents: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
     with:
       shas: ''

--- a/.github/workflows/example-codecoverage-cleanup.yml
+++ b/.github/workflows/example-codecoverage-cleanup.yml
@@ -1,0 +1,68 @@
+##
+# Example workflow for consumer repos that use reusable-codecoverage.
+#
+# Copy this file into your repo at .github/workflows/ (e.g. codecoverage-cleanup.yml).
+# It triggers cleanup on PR merge, branch delete, and weekly schedule.
+#
+# Prerequisites:
+#   - Your repo uses newfold-labs/workflows reusable-codecoverage and has a gh-pages branch.
+#   - No need to pass repo_token unless you use a different token for gh-pages; GITHUB_TOKEN is used by default.
+##
+name: Code Coverage Cleanup (example)
+
+on:
+  pull_request:
+    types: [closed]
+  delete:
+  schedule:
+    # Weekly on Sunday at 00:00 UTC
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  get-merged-pr-commits:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      shas: ${{ steps.shas.outputs.list }}
+    steps:
+      - name: Get PR commit SHAs
+        id: shas
+        run: |
+          list=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" --jq '[.[].sha] | @json') || list='[]'
+          [ -n "$list" ] || list='[]'
+          echo "list=${list}" >> "$GITHUB_OUTPUT"
+
+  cleanup-on-merge:
+    needs: get-merged-pr-commits
+    if: always() && needs.get-merged-pr-commits.result == 'success'
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
+    with:
+      shas: ${{ needs.get-merged-pr-commits.outputs.shas }}
+      prune_unreachable: false
+      squash_history: false
+    secrets: inherit
+
+  cleanup-on-branch-delete:
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch'
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
+    with:
+      shas: ''
+      prune_unreachable: true
+      squash_history: false
+    secrets: inherit
+
+  cleanup-scheduled:
+    if: github.event_name == 'schedule'
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
+    with:
+      shas: ''
+      prune_unreachable: true
+      squash_history: true
+    secrets: inherit

--- a/.github/workflows/example-codecoverage-cleanup.yml
+++ b/.github/workflows/example-codecoverage-cleanup.yml
@@ -9,6 +9,8 @@
 #   - No need to pass repo_token unless you use a different token for gh-pages; GITHUB_TOKEN is used by default.
 #
 # For stricter code scanning (pinned refs), replace @main with a commit SHA from newfold-labs/workflows.
+#
+# This workflow is skipped in the newfold-labs/workflows repo (no gh-pages coverage here); it runs when copied to other repos.
 ##
 name: Code Coverage Cleanup (example)
 
@@ -23,7 +25,7 @@ on:
 # Permissions set per-job to avoid overly broad write at workflow level.
 jobs:
   get-merged-pr-commits:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    if: github.repository != 'newfold-labs/workflows' && github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,7 +42,7 @@ jobs:
 
   cleanup-on-merge:
     needs: get-merged-pr-commits
-    if: always() && needs.get-merged-pr-commits.result == 'success'
+    if: github.repository != 'newfold-labs/workflows' && always() && needs.get-merged-pr-commits.result == 'success'
     permissions:
       contents: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
@@ -51,7 +53,7 @@ jobs:
     secrets: inherit
 
   cleanup-on-branch-delete:
-    if: github.event_name == 'delete' && github.event.ref_type == 'branch'
+    if: github.repository != 'newfold-labs/workflows' && github.event_name == 'delete' && github.event.ref_type == 'branch'
     permissions:
       contents: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
@@ -62,7 +64,7 @@ jobs:
     secrets: inherit
 
   cleanup-scheduled:
-    if: github.event_name == 'schedule'
+    if: github.repository != 'newfold-labs/workflows' && github.event_name == 'schedule'
     permissions:
       contents: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main

--- a/.github/workflows/example-codecoverage-cleanup.yml
+++ b/.github/workflows/example-codecoverage-cleanup.yml
@@ -14,7 +14,7 @@ name: Code Coverage Cleanup (example)
 
 on:
   pull_request:
-    types: [closed]
+    types: [ closed ]
   delete:
   schedule:
     # Weekly on Sunday at 00:00 UTC

--- a/.github/workflows/example-codecoverage.yml
+++ b/.github/workflows/example-codecoverage.yml
@@ -9,6 +9,8 @@
 #   - No need to pass repo_token unless you use a different token for gh-pages; GITHUB_TOKEN is used by default.
 #
 # To clean up stale gh-pages coverage dirs, add example-codecoverage-cleanup.yml as well.
+#
+# This workflow is skipped in the newfold-labs/workflows repo (no PHP/tests here); it runs when copied to other repos.
 ##
 name: Code Coverage (example)
 
@@ -24,6 +26,7 @@ permissions:
 
 jobs:
   codecoverage:
+    if: github.repository != 'newfold-labs/workflows'
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@f0b26152e4ea40cd40429e06b1f30aa8879e7392
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/example-codecoverage.yml
+++ b/.github/workflows/example-codecoverage.yml
@@ -1,0 +1,34 @@
+##
+# Example workflow for consumer repos that want to run the reusable code coverage workflow.
+#
+# Copy this file into your repo at .github/workflows/ (e.g. codecoverage.yml).
+# Update repository-name to match your repo (used for GitHub Pages coverage URLs).
+#
+# Prerequisites:
+#   - PHP/Composer project with PHPUnit (and optionally Codeception wpunit) tests.
+#   - No need to pass repo_token unless you use a different token for gh-pages; GITHUB_TOKEN is used by default.
+#
+# To clean up stale gh-pages coverage dirs, add example-codecoverage-cleanup.yml as well.
+##
+name: Code Coverage (example)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  codecoverage:
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    with:
+      php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
+      coverage-php-version: '7.4'
+      repository-name: 'your-repo-name'
+      minimum-coverage: 25
+      mysql-version: '5.7'
+    secrets: inherit

--- a/.github/workflows/example-codecoverage.yml
+++ b/.github/workflows/example-codecoverage.yml
@@ -14,9 +14,9 @@ name: Code Coverage (example)
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 permissions:
   contents: write

--- a/.github/workflows/example-codecoverage.yml
+++ b/.github/workflows/example-codecoverage.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   codecoverage:
-    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@f0b26152e4ea40cd40429e06b1f30aa8879e7392
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/reusable-codecoverage-cleanup.yml
+++ b/.github/workflows/reusable-codecoverage-cleanup.yml
@@ -1,0 +1,113 @@
+##
+# Reusable workflow to clean up stale code coverage directories on gh-pages and optionally squash branch history.
+#
+# Removes gh-pages/<sha>/ directories (one per commit that had coverage runs). Never touches gh-pages/phpunit/.
+#
+# Example usage (from a consumer repo that uses reusable-codecoverage):
+#   On PR merge: call with shas = all PR commit SHAs.
+#   On branch delete or schedule: call with prune_unreachable: true and optionally squash_history: true.
+#
+#   uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
+#   with:
+#     shas: '["abc123","def456"]'   # optional
+#     prune_unreachable: true       # optional
+#     squash_history: false         # optional
+##
+name: Reusable Code Coverage Cleanup
+
+on:
+  workflow_call:
+    inputs:
+      shas:
+        description: JSON array of commit SHAs whose gh-pages dirs to remove (e.g. all commits from a merged PR)
+        type: string
+        required: false
+      prune_unreachable:
+        description: If true, remove gh-pages/<sha>/ dirs for commits not reachable from any ref
+        type: boolean
+        default: false
+      squash_history:
+        description: If true, after cleanup replace gh-pages with a single orphan commit and force-push
+        type: boolean
+        default: false
+    secrets:
+      repo_token:
+        description: GitHub token for pushing to gh-pages (defaults to GITHUB_TOKEN if not set)
+        required: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository (all refs for reachability check)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Remove specific SHA directories
+        if: inputs.shas != ''
+        run: |
+          # Only remove dirs matching 40-char hex (safe)
+          for sha in $(echo '${{ inputs.shas }}' | jq -r '.[]'); do
+            if [ -n "$sha" ] && [ "${#sha}" -eq 40 ] && [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+              if [ -d "gh-pages/$sha" ]; then
+                rm -rf "gh-pages/$sha"
+                echo "Removed gh-pages/$sha"
+              fi
+            fi
+          done
+
+      - name: Prune unreachable SHA directories
+        if: inputs.prune_unreachable
+        run: |
+          for dir in gh-pages/*/; do
+            [ -d "$dir" ] || continue
+            name=$(basename "$dir")
+            if [ "${#name}" -eq 40 ] && [[ "$name" =~ ^[0-9a-f]{40}$ ]]; then
+              if ! git branch -a --contains "$name" 2>/dev/null | grep -q .; then
+                rm -rf "gh-pages/$name"
+                echo "Pruned unreachable gh-pages/$name"
+              fi
+            fi
+          done
+
+      - name: Commit and push cleanup (no squash)
+        if: inputs.squash_history != true
+        working-directory: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.repo_token || secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "chore: remove stale code coverage directories"
+          git push origin gh-pages
+
+      - name: Squash gh-pages to single commit and force-push
+        if: inputs.squash_history
+        working-directory: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.repo_token || secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Orphan commit keeps current tree (including any dir removals done above)
+          git checkout --orphan temp
+          git add -A
+          git commit -m "chore: code coverage (squashed)"
+          git branch -D gh-pages
+          git branch -m gh-pages
+          git push --force origin gh-pages

--- a/.github/workflows/reusable-codecoverage-cleanup.yml
+++ b/.github/workflows/reusable-codecoverage-cleanup.yml
@@ -46,7 +46,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
+      # Credentials left default so the later git push step can authenticate to origin.
       - name: Checkout gh-pages branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/reusable-codecoverage-cleanup.yml
+++ b/.github/workflows/reusable-codecoverage-cleanup.yml
@@ -43,14 +43,14 @@ jobs:
 
     steps:
       - name: Checkout repository (all refs for reachability check)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       # Credentials left default so the later git push step can authenticate to origin.
       - name: Checkout gh-pages branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/reusable-codecoverage.yml
+++ b/.github/workflows/reusable-codecoverage.yml
@@ -56,7 +56,31 @@ on:
 
 jobs:
 
+  check_gh_pages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      has_gh_pages: ${{ steps.check.outputs.has_gh_pages }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check if gh-pages branch exists
+        id: check
+        run: |
+          if git ls-remote --exit-code --heads origin gh-pages 2>/dev/null; then
+            echo "has_gh_pages=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_gh_pages=false" >> "$GITHUB_OUTPUT"
+            echo "gh-pages branch not found; skipping coverage job."
+          fi
+
   codecoverage:
+    needs: check_gh_pages
+    if: needs.check_gh_pages.outputs.has_gh_pages == 'true'
     runs-on: ubuntu-latest
     permissions:
       # Write access is needed to commit coverage reports to gh-pages branch
@@ -127,7 +151,7 @@ jobs:
           extensions: zip
 
       - name: Check for .env.testing.example
-        id: check-env-testing-example
+        id: check_env_testing_example
         run: |
           if [ -f ".env.testing.example" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -136,11 +160,11 @@ jobs:
           fi
 
       - name: Setup test environment
-        if: ${{ steps.check-env-testing-example.outputs.exists == 'true' }}
+        if: ${{ steps.check_env_testing_example.outputs.exists == 'true' }}
         run: cp .env.testing.example .env.testing
 
       - name: Read .env.testing
-        if: ${{ steps.check-env-testing-example.outputs.exists == 'true' }}
+        if: ${{ steps.check_env_testing_example.outputs.exists == 'true' }}
         uses: c-py/action-dotenv-to-setenv@925b5d99a3f1e4bd7b4e9928be4e2491e29891d9  # v5
         with:
           env-file: .env.testing
@@ -149,7 +173,7 @@ jobs:
         run: composer install -v
 
       - name: Check if wp-content directory exists
-        id: check-wp-content
+        id: check_wp_content
         run: |
           if [ -d "wp-content" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -158,7 +182,7 @@ jobs:
           fi
 
       - name: Allow writing to wp-content
-        if: ${{ steps.check-wp-content.outputs.exists == 'true' }}
+        if: ${{ steps.check_wp_content.outputs.exists == 'true' }}
         run: sudo chmod -R a+w wp-content
 
       # On main, there will be a previous coverage report. On PRs we create a new directory using the commit SHA.
@@ -169,7 +193,7 @@ jobs:
           mkdir gh-pages/phpunit || true;
 
       - name: Check if PHPUnit tests exist
-        id: check-unit-tests
+        id: check_unit_tests
         run: |
           if [ -d "tests/phpunit" ] && find tests/phpunit -name '*Test.php' -type f 2>/dev/null | grep -q .; then
             echo "has_tests=true" >> "$GITHUB_OUTPUT"
@@ -178,11 +202,11 @@ jobs:
           fi
 
       - name: Run PHPUnit tests
-        if: ${{ steps.check-unit-tests.outputs.has_tests == 'true' }}
+        if: ${{ steps.check_unit_tests.outputs.has_tests == 'true' }}
         run: XDEBUG_MODE=coverage vendor/bin/phpunit --bootstrap tests/phpunit/bootstrap.php --coverage-php tests/_output/unit.cov --debug
 
       - name: Check if WPUnit tests exist
-        id: check-wpunit-tests
+        id: check_wpunit_tests
         run: |
           if [ -d "tests/wpunit" ] && find tests/wpunit -name '*Test.php' -type f 2>/dev/null | grep -q .; then
             echo "has_tests=true" >> "$GITHUB_OUTPUT"
@@ -191,7 +215,7 @@ jobs:
           fi
 
       - name: Run WPUnit tests
-        if: ${{ steps.check-wpunit-tests.outputs.has_tests == 'true' }}
+        if: ${{ steps.check_wpunit_tests.outputs.has_tests == 'true' }}
         run: XDEBUG_MODE=coverage vendor/bin/codecept run wpunit --coverage tests/_output/wpunit.cov --debug
 
       - name: Run Integration tests
@@ -202,7 +226,7 @@ jobs:
       # Use the project-level <metrics> (has files="N") so we don't mix values from different elements (e.g. 100% from a class).
       - name: Get base branch coverage percentage
         if: ${{ matrix.php == inputs.coverage-php-version && github.event_name == 'pull_request' }}
-        id: base-coverage
+        id: base_coverage
         run: |
           base_pct=""
           clover="gh-pages/phpunit/clover.xml"
@@ -246,7 +270,7 @@ jobs:
       - name: Check test coverage
         if: ${{ matrix.php == inputs.coverage-php-version }}
         uses: johanvanhelden/gha-clover-test-coverage-check@2543c79a701f179bd63aa14c16c6938c509b2cec  # v1
-        id: coverage-percentage
+        id: coverage_percentage
         with:
           percentage: ${{ inputs.minimum-coverage }}
           exit: false
@@ -274,7 +298,7 @@ jobs:
         with:
           repository: gh-pages
           branch: gh-pages
-          commit_message: ${{ format('🤖 Save code coverage report to gh-pages {0}%', steps.coverage-percentage.outputs.coverage-rounded) }}
+          commit_message: ${{ format('🤖 Save code coverage report to gh-pages {0}%', steps.coverage_percentage.outputs.coverage-rounded) }}
           commit_options: ""
         env:
           GITHUB_TOKEN: "${{ secrets.repo_token }}"
@@ -282,8 +306,8 @@ jobs:
       - name: Add coverage comparison to PR comment
         if: ${{ matrix.php == inputs.coverage-php-version && github.event_name == 'pull_request' }}
         env:
-          BASE_COVERAGE: ${{ steps.base-coverage.outputs.base_coverage }}
-          PR_COVERAGE: ${{ steps.coverage-percentage.outputs.coverage-rounded }}
+          BASE_COVERAGE: ${{ steps.base_coverage.outputs.base_coverage }}
+          PR_COVERAGE: ${{ steps.coverage_percentage.outputs.coverage-rounded }}
         run: |
           {
             if [ -z "$PR_COVERAGE" ]; then
@@ -321,7 +345,7 @@ jobs:
       - name: Add coverage report link to PR comment
         if: ${{ matrix.php == inputs.coverage-php-version && github.event_name == 'pull_request' }}
         env:
-          PR_COVERAGE: ${{ steps.coverage-percentage.outputs.coverage-rounded }}
+          PR_COVERAGE: ${{ steps.coverage_percentage.outputs.coverage-rounded }}
           REPO_NAME: ${{ inputs.repository-name }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -353,8 +377,8 @@ jobs:
           echo "$OUTPUT" >> coverage-comment.md
 
       - name: Add coverage PR comment
-        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc  # v2.8.2
         if: ${{ matrix.php == inputs.coverage-php-version && github.event_name == 'pull_request' }}
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc  # v2.8.2
         continue-on-error: true  # When a PR is opened by a non-member, there are no write permissions (and no access to secrets), so this step will always fail.
         with:
           message-id: coverage-report
@@ -365,8 +389,8 @@ jobs:
       - name: Ensure coverage does not decrease
         if: ${{ matrix.php == inputs.coverage-php-version && github.event_name == 'pull_request' }}
         env:
-          BASE_COVERAGE: ${{ steps.base-coverage.outputs.base_coverage }}
-          PR_COVERAGE: ${{ steps.coverage-percentage.outputs.coverage-rounded }}
+          BASE_COVERAGE: ${{ steps.base_coverage.outputs.base_coverage }}
+          PR_COVERAGE: ${{ steps.coverage_percentage.outputs.coverage-rounded }}
         run: |
           # Only compare when both are non-empty and numeric (allow decimals, e.g. 16.45)
           case "$BASE_COVERAGE" in

--- a/.github/workflows/reusable-codecoverage.yml
+++ b/.github/workflows/reusable-codecoverage.yml
@@ -2,6 +2,8 @@
 # Reusable workflow for running PHPUnit unit and Codeception wp-browser wpunit tests,
 # merging code coverage, committing HTML reports to GitHub Pages, and generating coverage badges.
 #
+# Example workflows: example-codecoverage.yml (run coverage); example-codecoverage-cleanup.yml (cleanup gh-pages).
+#
 # Example usage:
 #   uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
 #   with:

--- a/.github/workflows/reusable-codecoverage.yml
+++ b/.github/workflows/reusable-codecoverage.yml
@@ -2,8 +2,6 @@
 # Reusable workflow for running PHPUnit unit and Codeception wp-browser wpunit tests,
 # merging code coverage, committing HTML reports to GitHub Pages, and generating coverage badges.
 #
-# Example workflows: example-codecoverage.yml (run coverage); example-codecoverage-cleanup.yml (cleanup gh-pages).
-#
 # Example usage:
 #   uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
 #   with:
@@ -11,6 +9,20 @@
 #     coverage-php-version: '7.4'
 #     repository-name: 'wp-module-activation'
 #     minimum-coverage: 25
+#
+# Associated cleanup workflow (removes stale gh-pages/<sha>/ dirs, optional squash):
+#   uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
+#   with:
+#     shas: '["abc123","def456"]'   # optional; e.g. all commits from a merged PR
+#     prune_unreachable: true       # optional; remove dirs for unreachable commits
+#     squash_history: false         # optional; squash gh-pages to one commit
+#   secrets: inherit
+#
+# Example workflows:
+#   - example-codecoverage.yml — call this reusable on push/PR to run tests and publish coverage.
+#   - example-codecoverage-cleanup.yml — removes stale gh-pages/<sha>/ dirs (from merged PRs or deleted branches)
+#     and can squash gh-pages history; trigger on PR merge, branch delete, or schedule. Copy into your repo to use.
+#
 ##
 name: Reusable Code Coverage
 

--- a/.github/workflows/reusable-codecoverage.yml
+++ b/.github/workflows/reusable-codecoverage.yml
@@ -68,10 +68,10 @@ jobs:
     services:
       mysql:
         image: mysql:${{ inputs.mysql-version }}
-        env: # These are the same username and password as the wp-env container defaults
+        env:  # These are the same username and password as the wp-env container defaults
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: tests-wordpress
-        ports: # This mapping matches the .wp-env.json configuration
+        ports:  # This mapping matches the .wp-env.json configuration
           - 33306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
@@ -82,9 +82,9 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          fetch-depth: 0 # attempting to get all branch names.
+          fetch-depth: 0  # attempting to get all branch names.
 
       # TODO: a DEPLOY_KEY is needed to enable gh-pages for the first time (the branch can be created and pushed but
       # it will not be reachable as a website).
@@ -113,13 +113,13 @@ jobs:
       #          commit_message: "🤖 Creating gh-pages branch"
 
       - name: Checkout GitHub Pages branch for code coverage report
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: gh-pages
           path: gh-pages
 
       - name: Install PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1  # v2.36.0
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
@@ -141,7 +141,7 @@ jobs:
 
       - name: Read .env.testing
         if: ${{ steps.check-env-testing-example.outputs.exists == 'true' }}
-        uses: c-py/action-dotenv-to-setenv@925b5d99a3f1e4bd7b4e9928be4e2491e29891d9 # v5
+        uses: c-py/action-dotenv-to-setenv@925b5d99a3f1e4bd7b4e9928be4e2491e29891d9  # v5
         with:
           env-file: .env.testing
 
@@ -195,7 +195,7 @@ jobs:
         run: XDEBUG_MODE=coverage vendor/bin/codecept run wpunit --coverage tests/_output/wpunit.cov --debug
 
       - name: Run Integration tests
-        if: ${{ hashFiles('tests/integration.suite') != '' }} # Only run integration tests if they are present.
+        if: ${{ hashFiles('tests/integration.suite') != '' }}  # Only run integration tests if they are present.
         run: XDEBUG_MODE=coverage vendor/bin/codecept run integration --debug
 
       # Read base (main) branch coverage from gh-pages for PR comparison. Main's coverage lives at gh-pages/phpunit/.
@@ -245,7 +245,7 @@ jobs:
       # PR coverage percentage. Uses action default rounded-precision (2 decimals). Output coverage-rounded is used for comment, commit message, and decrease check.
       - name: Check test coverage
         if: ${{ matrix.php == inputs.coverage-php-version }}
-        uses: johanvanhelden/gha-clover-test-coverage-check@2543c79a701f179bd63aa14c16c6938c509b2cec # v1
+        uses: johanvanhelden/gha-clover-test-coverage-check@2543c79a701f179bd63aa14c16c6938c509b2cec  # v1
         id: coverage-percentage
         with:
           percentage: ${{ inputs.minimum-coverage }}
@@ -261,7 +261,7 @@ jobs:
           git add -- .nojekyll *
 
       - name: Update README coverage badge
-        if: ${{ (matrix.php == inputs.coverage-php-version) && (github.ref == 'refs/heads/main') }} # only commit on main, on the PHP version we're using in production.
+        if: ${{ (matrix.php == inputs.coverage-php-version) && (github.ref == 'refs/heads/main') }}  # only commit on main, on the PHP version we're using in production.
         run: php-coverage-badger clover.xml gh-pages/phpunit/coverage.svg
 
       - name: Generate PR coverage badge
@@ -270,7 +270,7 @@ jobs:
 
       - name: Commit code coverage to gh-pages
         if: ${{ matrix.php == inputs.coverage-php-version }}
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v7.1.0
         with:
           repository: gh-pages
           branch: gh-pages
@@ -333,7 +333,7 @@ jobs:
 
       - name: Add phpcov uncovered lines report to PR comment
         if: ${{ matrix.php == inputs.coverage-php-version && github.event_name == 'pull_request' }}
-        continue-on-error: true # phpcov can fail if there are no uncovered lines
+        continue-on-error: true  # phpcov can fail if there are no uncovered lines
         env:
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -353,9 +353,9 @@ jobs:
           echo "$OUTPUT" >> coverage-comment.md
 
       - name: Add coverage PR comment
-        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc  # v2.8.2
         if: ${{ matrix.php == inputs.coverage-php-version && github.event_name == 'pull_request' }}
-        continue-on-error: true # When a PR is opened by a non-member, there are no write permissions (and no access to secrets), so this step will always fail.
+        continue-on-error: true  # When a PR is opened by a non-member, there are no write permissions (and no access to secrets), so this step will always fail.
         with:
           message-id: coverage-report
           message-path: coverage-comment.md


### PR DESCRIPTION
## Proposed changes

New cleanup workflow and examples for each reusable codecoverage workflow.

New reusable-codecoverage-cleanup.yml
- Inputs: shas (optional JSON array), prune_unreachable (boolean), squash_history (boolean).
- Optional secret: repo_token (falls back to GITHUB_TOKEN).
- Checkout: repo with fetch-depth: 0 (for reachability) and gh-pages into gh-pages/.
- Remove specific SHAs: if shas is set, deletes only top-level dirs whose names are 40-char hex.
- Prune unreachable: if prune_unreachable, lists top-level dirs in gh-pages/, treats 40-char hex names as SHAs, runs git branch -a --contains <sha> from the repo root, removes dirs for commits not in any branch.
- Commit and push: if not squashing, commits removals and pushes to gh-pages.
- Squash: if squash_history, creates an orphan commit with the current tree (including any removals), then force-pushes to gh-pages.
- Does not alter gh-pages/phpunit/ or other non-SHA paths. 

New example-codecoverage-cleanup.yml
- For consumer repos: copy into .github/workflows/ (e.g. as codecoverage-cleanup.yml).
- Triggers: pull_request closed, delete (branch), and weekly schedule (Sunday 00:00 UTC).
- On PR merge: job get-merged-pr-commits calls the API for that PR’s commits, then cleanup-on-merge calls the reusable with that SHA list.
- On branch delete: calls reusable with prune_unreachable: true.
- On schedule: calls reusable with prune_unreachable: true and squash_history: true.
- Uses secrets: inherit so the reusable gets the default token (or repo_token if the consumer sets it). 

New example-codecoverage.yml
- Example workflow for repos that want to use the reusable code coverage.
- Triggers: push to main, pull_request targeting main.
- Job: Calls reusable-codecoverage.yml@main with:
- php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
- coverage-php-version: '7.4'
- repository-name: 'your-repo-name' (placeholder for consumers to replace)
- minimum-coverage: 25
- mysql-version: '5.7'
- Uses secrets: inherit so the reusable gets GITHUB_TOKEN (or repo_token if set).
- Header comments explain copying to .github/workflows/, setting repository-name, and point to the cleanup example. 

Updated reusable-codecoverage.yml
- Added doc comment referencing the new cleanup and the associated example workflows.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->