### PR TITLE
Add .l10n.php syntax validation to translation workflows

### DIFF
--- a/.github/workflows/reusable-module-prep-release.yml
+++ b/.github/workflows/reusable-module-prep-release.yml
@@ -240,6 +240,42 @@ jobs:
             echo "message=ℹ️ Notice: i18n script not defined." >> "$GITHUB_OUTPUT"
           fi
 
+      # Workaround for WP-CLI bug: `wp i18n make-php` outputs a stray comma in
+      # the messages array when a PO file has zero translated strings, producing
+      # invalid PHP (e.g. 'messages' => [\n,\n]).  Strip the empty element so the
+      # generated file is syntactically valid.  See PRESS0-4223.
+      - name: Fix empty-messages comma in generated .l10n.php files
+        id: fix_l10n_comma
+        run: |
+          if [ -d languages ]; then
+            find languages -name '*.l10n.php' -print0 | while IFS= read -r -d '' f; do
+              if grep -qP "'messages'\s*=>\s*\[\s*," "$f"; then
+                sed -i -E "s/('messages'\s*=>\s*\[)\s*,/\1/" "$f"
+                echo "Fixed stray comma in $f"
+              fi
+            done
+          fi
+
+      # Validate that every generated .l10n.php file is syntactically valid PHP.
+      - name: Validate .l10n.php syntax
+        id: validate_l10n
+        run: |
+          errors=0
+          if [ -d languages ]; then
+            while IFS= read -r -d '' f; do
+              if ! php -l "$f" > /dev/null 2>&1; then
+                php -l "$f" 2>&1
+                errors=$((errors + 1))
+              fi
+            done < <(find languages -name '*.l10n.php' -print0)
+          fi
+          if [ "$errors" -gt 0 ]; then
+            echo "::error::Found $errors .l10n.php file(s) with PHP syntax errors."
+            exit 1
+          else
+            echo "All .l10n.php files passed syntax check."
+          fi
+
       - name: Get merged PRs since last tag/release
         id: merged-prs
         env:

--- a/.github/workflows/reusable-translations.yml
+++ b/.github/workflows/reusable-translations.yml
@@ -445,6 +445,43 @@ jobs:
           SCRIPT_LOCATION: ${{ inputs.i18n-script-location == 'npm' && 'npm' || 'composer' }}
         run: $SCRIPT_LOCATION run i18n-ci-post
 
+      # Workaround for WP-CLI bug: `wp i18n make-php` outputs a stray comma in
+      # the messages array when a PO file has zero translated strings, producing
+      # invalid PHP (e.g. 'messages' => [\n,\n]).  Strip the empty element so the
+      # generated file is syntactically valid.  See PRESS0-4223.
+      - name: Fix empty-messages comma in generated .l10n.php files
+        id: fix_l10n_comma
+        run: |
+          if [ -d languages ]; then
+            find languages -name '*.l10n.php' -print0 | while IFS= read -r -d '' f; do
+              if grep -qP "'messages'\s*=>\s*\[\s*," "$f"; then
+                sed -i -E "s/('messages'\s*=>\s*\[)\s*,/\1/" "$f"
+                echo "Fixed stray comma in $f"
+              fi
+            done
+          fi
+
+      # Validate that every generated .l10n.php file is syntactically valid PHP.
+      # This catches the WP-CLI bug above and any future generation issues.
+      - name: Validate .l10n.php syntax
+        id: validate_l10n
+        run: |
+          errors=0
+          if [ -d languages ]; then
+            while IFS= read -r -d '' f; do
+              if ! php -l "$f" > /dev/null 2>&1; then
+                php -l "$f" 2>&1
+                errors=$((errors + 1))
+              fi
+            done < <(find languages -name '*.l10n.php' -print0)
+          fi
+          if [ "$errors" -gt 0 ]; then
+            echo "::error::Found $errors .l10n.php file(s) with PHP syntax errors."
+            exit 1
+          else
+            echo "All .l10n.php files passed syntax check."
+          fi
+
       # Stages new language files so they are included in the diff and PR.
       - name: Add any new language files
         id: add_language_files


### PR DESCRIPTION
## Summary
- Fixes the root cause of PRESS0-4223: `wp i18n make-php` (WP-CLI) generates invalid PHP when a PO file has zero translated strings — a stray comma in an empty `messages` array causes a fatal parse error
- This broke WP Admin for Bluehost/HostGator customers using non-en_US locales (en_AU, en_GB, de_DE, etc.)
- Adds two steps to **both** `reusable-translations.yml` and `reusable-module-prep-release.yml`:
  1. **Auto-fix**: strips the known stray-comma pattern from generated `.l10n.php` files (workaround until WP-CLI is patched upstream)
  2. **Validate**: runs `php -l` on all `.l10n.php` files and fails the workflow if any have syntax errors — prevents broken translation files from ever shipping again

## Test plan
- [ ] Trigger a translation workflow on a module with empty PO files (no translated strings) and verify the fix step cleans up the output
- [ ] Trigger a prep-release workflow on a module with translations and verify validation passes
- [ ] Intentionally introduce a syntax error in a `.l10n.php` file and verify the validation step catches it

Fixes PRESS0-4223

🤖 Generated with [Claude Code](https://claude.com/claude-code)