### PR TITLE
chore(i18n): align Composer i18n scripts with WP-CLI

### DIFF
--- a/.github/workflows/reusable-translations.yml
+++ b/.github/workflows/reusable-translations.yml
@@ -438,7 +438,7 @@ jobs:
         if: inputs.i18n-script-location == 'npm'
         run: npm ci
 
-      # Runs i18n-ci-post to build MO/JSON so WordPress can use the translated strings.
+      # Runs i18n-ci-post to regenerate JED JSON and PHP (.l10n.php) translation files from PO catalogs.
       - name: Run i18n-ci-post scripts
         id: run_i18n_post
         env:
@@ -450,7 +450,7 @@ jobs:
         id: add_language_files
         run: git add -A languages/
 
-      # Captures i18n-ci-post changes (e.g. generated MO/JSON) for the artifact.
+      # Captures i18n-ci-post changes (e.g. generated JSON and .l10n.php) for the artifact.
       - name: Create a diff file
         id: create_diff
         run: |

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,8 @@
   "scripts": {
     "i18n-pot": "vendor/bin/wp i18n make-pot . ./languages/newfold-labs-workflows.pot --domain=newfold-labs-workflows --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/workflows/issues\",\"POT-Creation-Date\":\"2023-03-08T20:13:41+00:00\"}'",
     "i18n-po": "vendor/bin/wp i18n update-po ./languages/newfold-labs-workflows.pot ./languages",
-    "i18n-mo": "vendor/bin/wp i18n make-mo ./languages",
-    "i18n-php": "vendor/bin/wp i18n make-php ./languages",
-    "i18n-json": "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --no-purge --pretty-print",
+    "i18n-php": "vendor/bin/wp i18n make-php ./languages --pretty-print",
+    "i18n-json": "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --pretty-print",
     "i18n": [
       "@i18n-pot",
       "@i18n-po",
@@ -39,11 +38,13 @@
     ]
   },
   "scripts-descriptions": {
-    "i18n": "Generate new language files.",
-    "i18n-pot": "Generate a .pot file for translation.",
-    "i18n-po": "Update existing .po files.",
-    "i18n-mo": "Generate new language .mo files.",
-    "i18n-json": "Generate new language .json files."
+    "i18n-pot": "Scan source and generate the POT translation template using wp i18n make-pot.",
+    "i18n-po": "Update PO files from the POT file using wp i18n update-po.",
+    "i18n-php": "Generate PHP translation files from PO files using wp i18n make-php.",
+    "i18n-json": "Remove stale JSON catalogs, then generate JED JSON from PO files using wp i18n make-json.",
+    "i18n": "Run the full local i18n pipeline (POT, PO, PHP, JSON).",
+    "i18n-ci-pre": "CI: regenerate the POT file and sync PO catalogs from it.",
+    "i18n-ci-post": "CI: regenerate JED JSON and PHP translation files from PO catalogs."
   },
   "require-dev": {
     "wp-cli/i18n-command": "^2.6.5"


### PR DESCRIPTION
## Summary
Align `composer.json` i18n scripts with current WP-CLI i18n behavior and update reusable workflow comments.

## Changes
- Remove `--no-purge` from `wp i18n make-json` (SOP: `rm -f languages/*.json &&` kept for orphan Jed JSON cleanup).
- Add `--pretty-print` to `wp i18n make-php`.
- Remove `i18n-mo` / `make-mo`.
- Add `scripts-descriptions` for every script (including `i18n-ci-pre` / `i18n-ci-post`).
- `reusable-translations.yml`: comment fixes — i18n-ci-post produces JSON and `.l10n.php`, not MO.

## Verification
- `composer validate`
- `composer run-script --list`

Made with [Cursor](https://cursor.com)