### PR TITLE
fix(ci): sync gh-pages before push to avoid coverage publish races

### DIFF
--- a/.github/workflows/example-codecoverage-cleanup.yml
+++ b/.github/workflows/example-codecoverage-cleanup.yml
@@ -7,12 +7,17 @@
 # Prerequisites:
 #   - Your repo uses newfold-labs/workflows reusable-codecoverage and has a gh-pages branch.
 #   - No need to pass repo_token unless you use a different token for gh-pages; GITHUB_TOKEN is used by default.
+#   - Workflow concurrency below queues overlapping triggers per repo (gh-pages push races).
 #
 # For stricter code scanning (pinned refs), replace @main with a commit SHA from newfold-labs/workflows.
 #
 # This workflow is skipped in the newfold-labs/workflows repo (no gh-pages coverage here); it runs when copied to other repos.
 ##
 name: Code Coverage Cleanup (example)
+
+concurrency:
+  group: codecoverage-cleanup-${{ github.repository }}
+  cancel-in-progress: false
 
 on:
   pull_request:

--- a/.github/workflows/reusable-codecoverage-cleanup.yml
+++ b/.github/workflows/reusable-codecoverage-cleanup.yml
@@ -1,6 +1,10 @@
 ##
 # Reusable workflow to clean up stale code coverage directories on gh-pages and optionally squash branch history.
 #
+# Callers that may trigger this multiple times in parallel (e.g. closed PRs, branch delete, schedule) should use a
+# workflow concurrency group (same repo, cancel-in-progress: false) so gh-pages pushes do not race; non-squash pushes
+# also rebase/retry below.
+#
 # Removes gh-pages/<sha>/ directories (one per commit that had coverage runs). Never touches gh-pages/phpunit/.
 #
 # Example usage (from a consumer repo that uses reusable-codecoverage):
@@ -88,15 +92,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.repo_token || secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git add -A
           if git diff --staged --quiet; then
             echo "No changes to commit"
             exit 0
           fi
           git commit -m "chore: remove stale code coverage directories"
-          git push origin gh-pages
+          for attempt in 1 2 3; do
+            git fetch origin gh-pages
+            if ! git rebase origin/gh-pages; then
+              echo "::error::Rebase onto origin/gh-pages failed (conflict). Another job may have touched the same paths; resolve manually or re-run."
+              exit 1
+            fi
+            if git push origin gh-pages; then
+              echo "Push to gh-pages succeeded (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}); retrying after rebase..."
+          done
+          echo "::error::Could not push gh-pages cleanup after multiple attempts."
+          exit 1
 
       - name: Squash gh-pages to single commit and force-push
         if: inputs.squash_history
@@ -104,8 +123,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.repo_token || secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           # Orphan commit keeps current tree (including any dir removals done above)
           git checkout --orphan temp
           git add -A

--- a/.github/workflows/reusable-codecoverage.yml
+++ b/.github/workflows/reusable-codecoverage.yml
@@ -368,7 +368,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "$COMMIT_MESSAGE"
 
-          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+          for attempt in 1 2 3; do
             if git push origin HEAD:gh-pages; then
               echo "Push to gh-pages succeeded (attempt ${attempt})."
               exit 0

--- a/.github/workflows/reusable-codecoverage.yml
+++ b/.github/workflows/reusable-codecoverage.yml
@@ -286,16 +286,62 @@ jobs:
         if: ${{ matrix.php == inputs.coverage-php-version && github.event_name == 'pull_request' }}
         run: php-coverage-badger clover.xml gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/coverage.svg
 
+      # gh-pages is updated concurrently by other PRs/workflows; git-auto-commit-action only pushes and loses races.
+      # Sync to origin/gh-pages immediately before commit, then retry push with pull --rebase if another job landed first.
       - name: Commit code coverage to gh-pages
         if: ${{ matrix.php == inputs.coverage-php-version }}
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
-        with:
-          repository: gh-pages
-          branch: gh-pages
-          commit_message: ${{ format('🤖 Save code coverage report to gh-pages {0}%', steps.coverage-percentage.outputs.coverage-rounded) }}
-          commit_options: ""
+        working-directory: gh-pages
         env:
-          GITHUB_TOKEN: "${{ secrets.repo_token }}"
+          GITHUB_TOKEN: ${{ secrets.repo_token || github.token }}
+          COMMIT_MESSAGE: ${{ format('🤖 Save code coverage report to gh-pages {0}%', steps.coverage-percentage.outputs.coverage-rounded) }}
+        run: |
+          set -euo pipefail
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git fetch origin gh-pages
+
+          has_changes=false
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            has_changes=true
+          elif [ -n "$(git ls-files --others --exclude-standard)" ]; then
+            has_changes=true
+          fi
+
+          if [ "$has_changes" != true ]; then
+            echo "No coverage changes to publish; skipping commit/push."
+            exit 0
+          fi
+
+          git stash push -u -m "codecoverage-wip-${{ github.run_id }}-${{ github.run_attempt }}"
+          git reset --hard origin/gh-pages
+
+          if ! git stash pop; then
+            echo "::error::Could not restore coverage files after syncing gh-pages (merge conflict with concurrent update?). Re-run the workflow."
+            exit 1
+          fi
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing to commit after sync."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "$COMMIT_MESSAGE"
+
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            if git push origin HEAD:gh-pages; then
+              echo "Push to gh-pages succeeded (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Push rejected or failed (attempt ${attempt}); rebasing onto latest origin/gh-pages and retrying..."
+            git fetch origin gh-pages
+            git pull --rebase origin gh-pages
+          done
+
+          echo "::error::Could not push to gh-pages after multiple attempts."
+          exit 1
 
       - name: Add coverage comparison to PR comment
         if: ${{ matrix.php == inputs.coverage-php-version && github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Proposed changes

Coverage publishes to `gh-pages` often failed with a non-fast-forward push when another PR/workflow updated the branch between checkout and commit.

## Changes

- Replace `git-auto-commit-action` with an inline script that stashes local coverage output, resets to `origin/gh-pages`, restores changes, commits, and pushes.
- On push rejection, retry after `git pull --rebase origin/gh-pages` (up to 3 attempts).
- Use `secrets.repo_token || github.token` so push works when `repo_token` is omitted.
- Updated codecoverage-cleanup workflow with same strategy.
- Updated codecoverage-cleanup with recommended concurrency too.

Concurrent PR coverage runs can publish without racing each other off the branch tip.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->