### PR TITLE
use pluign version of wp-env to avoid mismatches in latest and current

### DIFF
--- a/.github/workflows/module-plugin-test-playwright.yml
+++ b/.github/workflows/module-plugin-test-playwright.yml
@@ -265,8 +265,10 @@ jobs:
           PACKAGE: ${{ steps.workflow.outputs.PACKAGE }}
         run: echo "{\"plugins\":[\"$DIST/$PACKAGE\"]}" > .wp-env.override.json
 
+      # Use the plugin's pinned @wordpress/env (via npx wp-env) so start/run share the same
+      # cache and runtime detection as Playwright global setup (matches plugin playwright workflows).
       - name: Install WordPress
-        run: npx @wordpress/env@latest start --debug
+        run: npx wp-env start --debug
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Proposed changes

Seeing issues with this workflow in a couple modules (https://github.com/newfold-labs/wp-module-link-tracker/actions/runs/25144415948/job/73701041631 & https://github.com/newfold-labs/wp-module-next-steps/actions/runs/25184569203/job/73964347578?pr=337) after updating wp-env in the plugin (https://github.com/newfold-labs/wp-plugin-bluehost/pull/1221)

The reusable workflow was starting the stack with npx @wordpress/env@latest start, while Playwright’s global setup uses npx wp-env run cli …. After npm ci, npx wp-env is the pinned @wordpress/env from the plugin’s package-lock.json (now 11.5.0), not necessarily the same code as @latest on the registry.

wp-env has moved toward explicit initialization tracking (for example runtime stored in wp-env-cache.json and stricter checks when the env is not considered started—see [WordPress/gutenberg#75057](https://github.com/WordPress/gutenberg/pull/75057)). If start and run are different versions, run can report “Environment not initialized. Run wp-env start first.” even though containers are up, because the CLI that started the env and the CLI running WP-CLI do not agree on that state.

The workflow now uses `npx wp-env start --debug` so start and run always use the plugin’s installed @wordpress/env.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->