### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/example-codecoverage-cleanup.yml
+++ b/.github/workflows/example-codecoverage-cleanup.yml
@@ -38,6 +38,7 @@ jobs:
     permissions:
       contents: read       # Required so `gh api` can read the (potentially private) repository's pull request resource.
       pull-requests: read  # Required so `gh api repos/{owner}/{repo}/pulls/{number}/commits` can list the merged pull request's commits.
+    timeout-minutes: 5
     outputs:
       shas: ${{ steps.shas.outputs.list }}
     steps:

--- a/.github/workflows/example-codecoverage-cleanup.yml
+++ b/.github/workflows/example-codecoverage-cleanup.yml
@@ -27,14 +27,17 @@ on:
     # Weekly on Sunday at 00:00 UTC
     - cron: '0 0 * * 0'
 
-# Permissions set per-job to avoid overly broad write at workflow level.
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   get-merged-pr-commits:
     if: github.repository != 'newfold-labs/workflows' && github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read       # Required so `gh api` can read the (potentially private) repository's pull request resource.
+      pull-requests: read  # Required so `gh api repos/{owner}/{repo}/pulls/{number}/commits` can list the merged pull request's commits.
     outputs:
       shas: ${{ steps.shas.outputs.list }}
     steps:
@@ -49,7 +52,7 @@ jobs:
     needs: get-merged-pr-commits
     if: github.repository != 'newfold-labs/workflows' && always() && needs.get-merged-pr-commits.result == 'success'
     permissions:
-      contents: write
+      contents: write # Required so the reusable workflow can commit and push the gh-pages cleanup back to the gh-pages branch.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
     with:
       shas: ${{ needs.get-merged-pr-commits.outputs.shas }}
@@ -60,7 +63,7 @@ jobs:
   cleanup-on-branch-delete:
     if: github.repository != 'newfold-labs/workflows' && github.event_name == 'delete' && github.event.ref_type == 'branch'
     permissions:
-      contents: write
+      contents: write # Required so the reusable workflow can commit and push the gh-pages cleanup back to the gh-pages branch.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
     with:
       shas: ''
@@ -71,7 +74,7 @@ jobs:
   cleanup-scheduled:
     if: github.repository != 'newfold-labs/workflows' && github.event_name == 'schedule'
     permissions:
-      contents: write
+      contents: write # Required so the reusable workflow can commit (and optionally force-push the squashed history) to the gh-pages branch.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main
     with:
       shas: ''

--- a/.github/workflows/example-codecoverage.yml
+++ b/.github/workflows/example-codecoverage.yml
@@ -20,13 +20,16 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   codecoverage:
     if: github.repository != 'newfold-labs/workflows'
+    permissions:
+      contents: write      # Required so the reusable workflow can commit coverage reports to the gh-pages branch.
+      pull-requests: write # Required so the reusable workflow can post coverage comments on pull requests.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@f0b26152e4ea40cd40429e06b1f30aa8879e7392
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -22,15 +22,14 @@ on:
         required: true
 
 # Disable permissions for all available scopes by default.
-# Any needed permissions should be configured individually for each job.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read # Required for actions/checkout to clone the (private) caller repository. The Crowdin action uses NEWFOLD_ACCESS_TOKEN (a PAT) for any branch push or PR creation, so the workflow's GITHUB_TOKEN does not need write scopes.
 
     steps:
       - name: Checkout

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for actions/checkout to clone the (private) caller repository. The Crowdin action uses NEWFOLD_ACCESS_TOKEN (a PAT) for any branch push or PR creation, so the workflow's GITHUB_TOKEN does not need write scopes.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for actions/checkout to clone the (private) caller repository. The Crowdin action only uploads sources/translations to Crowdin via CROWDIN_PERSONAL_TOKEN, so the workflow's GITHUB_TOKEN does not need write scopes.
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -14,13 +14,15 @@ on:
       CROWDIN_PERSONAL_TOKEN:
         required: true
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required for actions/checkout to clone the (private) caller repository. The Crowdin action only uploads sources/translations to Crowdin via CROWDIN_PERSONAL_TOKEN, so the workflow's GITHUB_TOKEN does not need write scopes.
 
     steps:
       - name: Checkout

--- a/.github/workflows/i18n-update.yml
+++ b/.github/workflows/i18n-update.yml
@@ -16,15 +16,14 @@ on:
         required: true
 
 # Disable permissions for all available scopes by default.
-# Any needed permissions should be configured individually for each job.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   update-i18n:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # Required so the persisted GITHUB_TOKEN can push the generated translation branch back to the repository. The pull request itself is opened via actions/github-script using NEWFOLD_ACCESS_TOKEN, so pull-requests: write is not needed on GITHUB_TOKEN.
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/i18n-update.yml
+++ b/.github/workflows/i18n-update.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required so the persisted GITHUB_TOKEN can push the generated translation branch back to the repository. The pull request itself is opened via actions/github-script using NEWFOLD_ACCESS_TOKEN, so pull-requests: write is not needed on GITHUB_TOKEN.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/module-plugin-test-playwright.yml
+++ b/.github/workflows/module-plugin-test-playwright.yml
@@ -98,6 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for actions/checkout to clone the (private) plugin repository.
+    timeout-minutes: 45
     env:
       MODULE_REPO: ${{ inputs.module-repo }}
     steps:

--- a/.github/workflows/module-plugin-test-playwright.yml
+++ b/.github/workflows/module-plugin-test-playwright.yml
@@ -97,7 +97,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Required for actions/checkout to clone the (private) plugin repository.
     env:
       MODULE_REPO: ${{ inputs.module-repo }}
     steps:

--- a/.github/workflows/module-plugin-test-playwright.yml
+++ b/.github/workflows/module-plugin-test-playwright.yml
@@ -89,7 +89,7 @@ on:
         required: false
 
 # Disable permissions for all available scopes by default.
-# Any needed permissions should be configured individually for each job.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:

--- a/.github/workflows/module-plugin-test.yml
+++ b/.github/workflows/module-plugin-test.yml
@@ -84,7 +84,7 @@ on:
         required: true
 
 # Disable permissions for all available scopes by default.
-# Any needed permissions should be configured individually for each job.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:

--- a/.github/workflows/module-plugin-test.yml
+++ b/.github/workflows/module-plugin-test.yml
@@ -92,7 +92,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Required for actions/checkout to clone the (private) plugin repository.
     env:
       MODULE_REPO: ${{ inputs.module-repo }}
     steps:

--- a/.github/workflows/module-plugin-test.yml
+++ b/.github/workflows/module-plugin-test.yml
@@ -93,6 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for actions/checkout to clone the (private) plugin repository.
+    timeout-minutes: 45
     env:
       MODULE_REPO: ${{ inputs.module-repo }}
     steps:

--- a/.github/workflows/reusable-cloudflare-worker-deploy.yml
+++ b/.github/workflows/reusable-cloudflare-worker-deploy.yml
@@ -24,7 +24,7 @@ jobs:
     name: Deploy Cloudflare Worker
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Required for actions/checkout to clone the (private) caller repository. The deploy step authenticates to Cloudflare via CLOUDFLARE_API_TOKEN, not GITHUB_TOKEN.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-cloudflare-worker-deploy.yml
+++ b/.github/workflows/reusable-cloudflare-worker-deploy.yml
@@ -16,7 +16,7 @@ on:
         required: true
 
 # Disable permissions for all available scopes by default.
-# Any needed permissions should be configured individually for each job.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:

--- a/.github/workflows/reusable-cloudflare-worker-deploy.yml
+++ b/.github/workflows/reusable-cloudflare-worker-deploy.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for actions/checkout to clone the (private) caller repository. The deploy step authenticates to Cloudflare via CLOUDFLARE_API_TOKEN, not GITHUB_TOKEN.
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-codecoverage-cleanup.yml
+++ b/.github/workflows/reusable-codecoverage-cleanup.yml
@@ -39,11 +39,15 @@ on:
         description: GitHub token for pushing to gh-pages (defaults to GITHUB_TOKEN if not set)
         required: false
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # Required to clone the (private) caller repository and to push the gh-pages cleanup commit (or force-push the squashed history) using the persisted GITHUB_TOKEN.
 
     steps:
       - name: Checkout repository (all refs for reachability check)

--- a/.github/workflows/reusable-codecoverage-cleanup.yml
+++ b/.github/workflows/reusable-codecoverage-cleanup.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required to clone the (private) caller repository and to push the gh-pages cleanup commit (or force-push the squashed history) using the persisted GITHUB_TOKEN.
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository (all refs for reachability check)

--- a/.github/workflows/reusable-codecoverage.yml
+++ b/.github/workflows/reusable-codecoverage.yml
@@ -54,12 +54,16 @@ on:
         description: GitHub token for committing to gh-pages
         required: false
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
   check_gh_pages:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Required for actions/checkout to clone the (private) caller repository so we can ask the remote about the gh-pages branch.
     outputs:
       has_gh_pages: ${{ steps.check.outputs.has_gh_pages }}
     steps:
@@ -83,11 +87,8 @@ jobs:
     if: needs.check_gh_pages.outputs.has_gh_pages == 'true'
     runs-on: ubuntu-latest
     permissions:
-      # Write access is needed to commit coverage reports to gh-pages branch
-      # (write permission includes read access for checkout)
-      contents: write
-      # Write access is needed to post comments on pull requests
-      pull-requests: write
+      contents: write      # Required to clone the (private) caller repository and to commit/push code coverage reports to the gh-pages branch (write implies read).
+      pull-requests: write # Required so the mshick/add-pr-comment step can create or update the coverage report comment on pull requests.
 
     services:
       mysql:

--- a/.github/workflows/reusable-codecoverage.yml
+++ b/.github/workflows/reusable-codecoverage.yml
@@ -64,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for actions/checkout to clone the (private) caller repository so we can ask the remote about the gh-pages branch.
+    timeout-minutes: 5
     outputs:
       has_gh_pages: ${{ steps.check.outputs.has_gh_pages }}
     steps:
@@ -89,6 +90,7 @@ jobs:
     permissions:
       contents: write      # Required to clone the (private) caller repository and to commit/push code coverage reports to the gh-pages branch (write implies read).
       pull-requests: write # Required so the mshick/add-pr-comment step can create or update the coverage report comment on pull requests.
+    timeout-minutes: 45
 
     services:
       mysql:

--- a/.github/workflows/reusable-file-size-audit.yml
+++ b/.github/workflows/reusable-file-size-audit.yml
@@ -7,13 +7,17 @@ env:
   MAX_IMAGE_SIZE_KB: 500
   MAX_PHP_SIZE_INCREASE_PERCENT: 15
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   audit:
     name: Audit Plugin Size
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read       # Required for actions/checkout to clone the (private) caller repository (both head and base refs).
+      pull-requests: write # Required so the actions/github-script step can create or update the size-audit comment on pull requests.
 
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-file-size-audit.yml
+++ b/.github/workflows/reusable-file-size-audit.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: read       # Required for actions/checkout to clone the (private) caller repository (both head and base refs).
       pull-requests: write # Required so the actions/github-script step can create or update the size-audit comment on pull requests.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-image-optimization.yml
+++ b/.github/workflows/reusable-image-optimization.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write      # Required so calibreapp/image-actions can commit optimized images back to the pull request head branch, and so peter-evans/create-pull-request can push a new image-optimization branch on push events.
       pull-requests: write # Required so calibreapp/image-actions can comment on the pull request with the optimization summary and so peter-evans/create-pull-request can open the optimization PR.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-image-optimization.yml
+++ b/.github/workflows/reusable-image-optimization.yml
@@ -7,13 +7,18 @@ on:
         description: 'The event that triggered the workflow'
         required: true
         type: string
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   optimize-images:
     name: Optimize Images
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required so calibreapp/image-actions can commit optimized images back to the pull request head branch, and so peter-evans/create-pull-request can push a new image-optimization branch on push events.
+      pull-requests: write # Required so calibreapp/image-actions can comment on the pull request with the optimization summary and so peter-evans/create-pull-request can open the optimization PR.
 
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-module-prep-release.yml
+++ b/.github/workflows/reusable-module-prep-release.yml
@@ -61,6 +61,7 @@ jobs:
     permissions:
       contents: write      # Required to clone the target repository and push the auto-generated `release/<new-version>` branch using the persisted GITHUB_TOKEN.
       pull-requests: write # Required so `gh pr create` can open the draft release pull request against the module's target branch.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/reusable-module-prep-release.yml
+++ b/.github/workflows/reusable-module-prep-release.yml
@@ -59,9 +59,8 @@ jobs:
     name: Prepare Release
     runs-on: ubuntu-latest
     permissions:
-      # Give the default token permission to commit, push the changed files, and open a pull request.
-      contents: write
-      pull-requests: write
+      contents: write      # Required to clone the target repository and push the auto-generated `release/<new-version>` branch using the persisted GITHUB_TOKEN.
+      pull-requests: write # Required so `gh pr create` can open the draft release pull request against the module's target branch.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/reusable-plugin-prep-release.yml
+++ b/.github/workflows/reusable-plugin-prep-release.yml
@@ -66,8 +66,8 @@ jobs:
     name: Prepare Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required to clone the target plugin repository and push the auto-generated `release/<new-version>` branch using the persisted GITHUB_TOKEN.
+      pull-requests: write # Required so `gh pr create` can open the draft release pull request against the plugin's target branch.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/reusable-plugin-prep-release.yml
+++ b/.github/workflows/reusable-plugin-prep-release.yml
@@ -68,6 +68,7 @@ jobs:
     permissions:
       contents: write      # Required to clone the target plugin repository and push the auto-generated `release/<new-version>` branch using the persisted GITHUB_TOKEN.
       pull-requests: write # Required so `gh pr create` can open the draft release pull request against the plugin's target branch.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/reusable-translations.yml
+++ b/.github/workflows/reusable-translations.yml
@@ -89,6 +89,7 @@ jobs:
     permissions:
       contents: write     # Required to clone the (private) caller repository and to push/delete the `auto-translate/<ref>` branch using the persisted GITHUB_TOKEN.
       pull-requests: read # Required so `gh pr list` and `gh pr update-branch` can locate an existing translations pull request.
+    timeout-minutes: 10
     outputs:
       pr_found: ${{ steps.check_pr.outputs.found }}
 
@@ -169,6 +170,7 @@ jobs:
     needs: [ 'prepare-pr-branch' ]
     permissions:
       contents: read # Required for actions/checkout to clone the (private) caller repository at the auto-translate branch.
+    timeout-minutes: 20
     outputs:
       has_untranslated: ${{ steps.check_untranslated.outputs.has_untranslated }}
 
@@ -287,6 +289,7 @@ jobs:
       needs.prepare-for-translation.outputs.has_untranslated == 'true'
     permissions:
       contents: read # Required for actions/checkout to clone the (private) caller repository at the auto-translate branch.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -386,6 +389,7 @@ jobs:
       )
     permissions:
       contents: read # Required for actions/checkout to clone the (private) caller repository at the auto-translate branch.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository
@@ -499,6 +503,7 @@ jobs:
     permissions:
       contents: write      # Required to clone the (private) caller repository and to push the auto-translate branch using the persisted GITHUB_TOKEN.
       pull-requests: write # Required so `gh pr create` can open the translations pull request when no open one exists yet.
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/reusable-translations.yml
+++ b/.github/workflows/reusable-translations.yml
@@ -87,8 +87,8 @@ jobs:
     name: Prepare Pull Request Branch
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: read
+      contents: write     # Required to clone the (private) caller repository and to push/delete the `auto-translate/<ref>` branch using the persisted GITHUB_TOKEN.
+      pull-requests: read # Required so `gh pr list` and `gh pr update-branch` can locate an existing translations pull request.
     outputs:
       pr_found: ${{ steps.check_pr.outputs.found }}
 
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ 'prepare-pr-branch' ]
     permissions:
-      contents: read
+      contents: read # Required for actions/checkout to clone the (private) caller repository at the auto-translate branch.
     outputs:
       has_untranslated: ${{ steps.check_untranslated.outputs.has_untranslated }}
 
@@ -286,7 +286,7 @@ jobs:
       inputs.run-azure-ai-translate &&
       needs.prepare-for-translation.outputs.has_untranslated == 'true'
     permissions:
-      contents: read
+      contents: read # Required for actions/checkout to clone the (private) caller repository at the auto-translate branch.
 
     steps:
       - name: Checkout repository
@@ -385,7 +385,7 @@ jobs:
         needs.auto-translate-with-azure.result == 'skipped'
       )
     permissions:
-      contents: read
+      contents: read # Required for actions/checkout to clone the (private) caller repository at the auto-translate branch.
 
     steps:
       - name: Checkout repository
@@ -497,8 +497,8 @@ jobs:
       ) &&
       needs.process-translations.result == 'success'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required to clone the (private) caller repository and to push the auto-translate branch using the persisted GITHUB_TOKEN.
+      pull-requests: write # Required so `gh pr create` can open the translations pull request when no open one exists yet.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/reusable-translations.yml
+++ b/.github/workflows/reusable-translations.yml
@@ -67,12 +67,12 @@ on:
       TRANSLATOR_API_KEY:
         required: true
 
-# Disable permissions for all available scopes by default.
-# Any needed permissions should be configured individually for each job.
-permissions: {}
-
 env:
   PR_BRANCH_NAME: ${{ format( 'auto-translate/{0}', ( github.event_name == 'pull_request' && github.head_ref || github.ref_name ) ) }}
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   # This job works to ensure that the HEAD branch is present and up to date with the BASE branch.

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for actions/checkout to clone the (private) caller repository so yamllint can scan its YAML files.
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -122,6 +123,7 @@ jobs:
     permissions:
       security-events: write # Required so github/codeql-action/upload-sarif can publish Poutine results to the repository's code scanning alerts.
       contents: read         # Required for actions/checkout to clone the (private) caller repository so Poutine can scan its build pipelines.
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -152,6 +154,7 @@ jobs:
       security-events: write # Required so the zizmor action can publish SARIF results to the repository's code scanning alerts.
       actions: read          # Required by the zizmor action to inspect workflow run metadata while scanning.
       contents: read         # Required for actions/checkout to clone the (private) caller repository so zizmor can scan its workflow files.
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 
 # Disable permissions for all available scopes by default.
-# Any needed permissions should be configured individually for each job.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -15,7 +15,7 @@ jobs:
   yaml-lint:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Required for actions/checkout to clone the (private) caller repository so yamllint can scan its YAML files.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -52,7 +52,7 @@ jobs:
     name: Actionlint
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: read # Required for actions/checkout to clone the (private) caller repository so actionlint can scan its workflow files.
     timeout-minutes: 5
     steps:
       - name: Checkout repository
@@ -80,9 +80,9 @@ jobs:
     name: Octoscan
     runs-on: ubuntu-24.04
     permissions:
-      security-events: write
-      actions: read
-      contents: read
+      security-events: write # Required so github/codeql-action/upload-sarif can publish octoscan results to the repository's code scanning alerts.
+      actions: read          # Required by github/codeql-action/upload-sarif to read the workflow run metadata associated with the SARIF upload.
+      contents: read         # Required for actions/checkout to clone the (private) caller repository so octoscan can scan its workflow files.
     timeout-minutes: 10
     steps:
       - name: Checkout repository
@@ -120,8 +120,8 @@ jobs:
     name: Poutine
     runs-on: ubuntu-24.04
     permissions:
-      security-events: write
-      contents: read
+      security-events: write # Required so github/codeql-action/upload-sarif can publish Poutine results to the repository's code scanning alerts.
+      contents: read         # Required for actions/checkout to clone the (private) caller repository so Poutine can scan its build pipelines.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -149,9 +149,9 @@ jobs:
     name: zizmor
     runs-on: ubuntu-24.04
     permissions:
-      security-events: write
-      actions: read
-      contents: read
+      security-events: write # Required so the zizmor action can publish SARIF results to the repository's code scanning alerts.
+      actions: read          # Required by the zizmor action to inspect workflow run metadata while scanning.
+      contents: read         # Required for actions/checkout to clone the (private) caller repository so zizmor can scan its workflow files.
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,8 +23,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
-  # Disable permissions for all available scopes by default.
-  # Any needed permissions should be configured individually for each job.
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
     name: 'Run translation script tests'
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: read
+      contents: read # Required for actions/checkout to clone the repository so pytest can run against the translation script sources.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     permissions:
       contents: read # Required for actions/checkout to clone the repository so pytest can run against the translation script sources.
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/verify-module-plugin-test.yml
+++ b/.github/workflows/verify-module-plugin-test.yml
@@ -31,7 +31,7 @@ jobs:
   verify-module-plugin-test:
     name: ${{ matrix.name }} (${{ format( '{0}{1}{2}', matrix.module, ( matrix.secondary-module-repo && format( '{0}{1}', ' with ', matrix.secondary-module-repo ) || '' ), ( ! matrix.only-module-tests && ' - all tests' || '' ) ) }})
     permissions:
-      contents: read
+      contents: read # Required so the called module-plugin-test-playwright workflow can use actions/checkout to clone the target plugin repository.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/verify-module-plugin-test.yml
+++ b/.github/workflows/verify-module-plugin-test.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.
-# Any needed permissions should be configured individually for each job.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -142,7 +142,7 @@ jobs:
             module: 'notifications'
             only-module-tests: false
 
-    uses: ./.github/workflows/module-plugin-test-playwright.yml
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@${{ github.sha }}
     with:
       plugin-repo: ${{ matrix.plugin-repo }}
       module-repo: newfold-labs/wp-module-${{ matrix.module }}

--- a/.github/workflows/verify-translations.yml
+++ b/.github/workflows/verify-translations.yml
@@ -27,8 +27,8 @@ jobs:
   translate:
     name: 'Check and update translations'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required so the reusable translations workflow can push the auto-translate branch and the eventual translation commit.
+      pull-requests: write # Required so the reusable translations workflow can open the translations pull request.
     uses: ./.github/workflows/reusable-translations.yml
     with:
       text_domain: 'newfold-labs-workflows'

--- a/.github/workflows/verify-translations.yml
+++ b/.github/workflows/verify-translations.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.
-# Any needed permissions should be configured individually for each job.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: write      # Required so the reusable translations workflow can push the auto-translate branch and the eventual translation commit.
       pull-requests: write # Required so the reusable translations workflow can open the translations pull request.
-    uses: ./.github/workflows/reusable-translations.yml
+    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@${{ github.sha }}
     with:
       text_domain: 'newfold-labs-workflows'
     secrets:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -28,7 +28,7 @@ jobs:
   lint:
     name: Scan & lint workflow files
     permissions:
-      security-events: write
-      actions: read
-      contents: read
+      security-events: write # Required so the reusable workflow's octoscan/poutine/zizmor jobs can upload SARIF results to the repository's code scanning alerts.
+      actions: read          # Required by github/codeql-action/upload-sarif (and zizmor) inside the reusable workflow to inspect workflow run metadata.
+      contents: read         # Required so the reusable workflow's actions/checkout steps can clone this repository before scanning its workflow files.
     uses: ./.github/workflows/reusable-workflow-lint.yml

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.
-# Any needed permissions should be configured individually for each job.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
@@ -31,4 +31,4 @@ jobs:
       security-events: write # Required so the reusable workflow's octoscan/poutine/zizmor jobs can upload SARIF results to the repository's code scanning alerts.
       actions: read          # Required by github/codeql-action/upload-sarif (and zizmor) inside the reusable workflow to inspect workflow run metadata.
       contents: read         # Required so the reusable workflow's actions/checkout steps can clone this repository before scanning its workflow files.
-    uses: ./.github/workflows/reusable-workflow-lint.yml
+    uses: newfold-labs/workflows/.github/workflows/reusable-workflow-lint.yml@${{ github.sha }}


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/newfold-labs/workflows/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

No analysis summary was found in the subagent logs for this repository.


