### PR TITLE
PRESS0-4774: support install-time tooling that needs newer PHP

### DIFF
--- a/.github/workflows/example-codecoverage.yml
+++ b/.github/workflows/example-codecoverage.yml
@@ -34,4 +34,5 @@ jobs:
       repository-name: 'your-repo-name'
       minimum-coverage: 25
       mysql-version: '5.7'
+      # install-php-version: '8.3'  # optional; PHP used only for composer install, e.g. when install-time tooling needs a newer PHP than the oldest matrix version
     secrets: inherit

--- a/.github/workflows/reusable-codecoverage.yml
+++ b/.github/workflows/reusable-codecoverage.yml
@@ -49,6 +49,10 @@ on:
         description: MySQL version for the service container
         type: string
         default: '5.7'
+      install-php-version:
+        description: Optional PHP version used only for the composer install step (defaults to the matrix PHP version under test). Useful when install-time tooling (e.g. PHP-Scoper) requires a newer PHP than the oldest test runtime; the lock file and platform config keep the installed dependencies identical.
+        type: string
+        default: ''
     secrets:
       repo_token:
         description: GitHub token for committing to gh-pages
@@ -169,8 +173,29 @@ jobs:
         with:
           env-file: .env.testing
 
+      # Optionally run composer install on a newer PHP than the matrix version
+      # under test, for repos whose install-time tooling needs it. The matrix
+      # PHP is restored right after, so tests still run on the version under test.
+      - name: Switch PHP for composer install
+        if: ${{ inputs.install-php-version != '' && inputs.install-php-version != matrix.php }}
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: ${{ inputs.install-php-version }}
+          coverage: none
+          tools: composer
+          extensions: zip
+
       - name: Run composer install
         run: composer install -v
+
+      - name: Restore matrix PHP version
+        if: ${{ inputs.install-php-version != '' && inputs.install-php-version != matrix.php }}
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: xdebug
+          tools: composer, jaschilz/php-coverage-badger
+          extensions: zip
 
       - name: Check if wp-content directory exists
         id: check_wp_content

--- a/.github/workflows/reusable-codecoverage.yml
+++ b/.github/workflows/reusable-codecoverage.yml
@@ -9,6 +9,7 @@
 #     coverage-php-version: '7.4'
 #     repository-name: 'wp-module-activation'
 #     minimum-coverage: 25
+#     install-php-version: '8.3'   # optional; PHP used only for composer install (see input description)
 #
 # Associated cleanup workflow (removes stale gh-pages/<sha>/ dirs, optional squash):
 #   uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage-cleanup.yml@main

--- a/.github/workflows/reusable-plugin-prep-release.yml
+++ b/.github/workflows/reusable-plugin-prep-release.yml
@@ -27,6 +27,10 @@ on:
         description: The version of Node.js to be used.
         type: string
         default: '20'
+      php-version:
+        description: The version of PHP to be used. Repos whose composer install runs install-time tooling (e.g. PHP-Scoper) may need a newer version than the default.
+        type: string
+        default: '8.1'
       level:
         description: The level of release to be used (patch, minor, major).
         type: string
@@ -81,7 +85,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f  # v2.37.0
         with:
-          php-version: '8.1'
+          php-version: '${{ inputs.php-version }}'
           coverage: none
           tools: composer
 

--- a/.github/workflows/reusable-plugin-prep-release.yml
+++ b/.github/workflows/reusable-plugin-prep-release.yml
@@ -27,10 +27,6 @@ on:
         description: The version of Node.js to be used.
         type: string
         default: '20'
-      php-version:
-        description: The version of PHP to be used. Repos whose composer install runs install-time tooling (e.g. PHP-Scoper) may need a newer version than the default.
-        type: string
-        default: '8.1'
       level:
         description: The level of release to be used (patch, minor, major).
         type: string
@@ -85,7 +81,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f  # v2.37.0
         with:
-          php-version: '${{ inputs.php-version }}'
+          php-version: '8.3'
           coverage: none
           tools: composer
 

--- a/.github/workflows/reusable-translations.yml
+++ b/.github/workflows/reusable-translations.yml
@@ -23,6 +23,10 @@
 #   i18n-script-location (optional, default: 'composer')
 #     Where i18n scripts are run from. Use "npm" if the repo runs i18n via package.json (e.g. @wordpress/scripts).
 #
+#   php-version (optional, default: '8.0')
+#     PHP version used to run Composer and the i18n scripts. Repos whose composer install runs install-time tooling
+#     (e.g. PHP-Scoper) may need a newer version than the default.
+#
 #   po-wrapwidth (optional, default: 77)
 #     Line wrap width when the Python script saves PO files (gettext-style). Only used when the translate script actually writes a file; ignored when po-nowrap is true. Use to match your gettext/xgettext wrap width and reduce formatting-only diffs.
 #
@@ -52,6 +56,11 @@ on:
         required: false
         type: string
         default: 'composer'
+      php-version:
+        description: 'PHP version used to run Composer and the i18n scripts. Repos whose composer install runs install-time tooling (e.g. PHP-Scoper) may need a newer version than the default.'
+        required: false
+        type: string
+        default: '8.0'
       po-wrapwidth:
         description: 'Line wrap width when saving PO files (default 77, match gettext). Ignored when po-nowrap is true.'
         required: false
@@ -185,7 +194,7 @@ jobs:
         id: setup_php
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
-          php-version: "8.0"
+          php-version: "${{ inputs.php-version }}"
 
       # Installs Composer deps so i18n-ci-pre (and i18n-ci-post in a later job) can run.
       - name: Install Composer dependencies
@@ -415,7 +424,7 @@ jobs:
         id: setup_php
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
-          php-version: "8.0"
+          php-version: "${{ inputs.php-version }}"
 
       # Installs Composer deps so i18n-ci-post can run.
       - name: Install Composer dependencies

--- a/.github/workflows/reusable-translations.yml
+++ b/.github/workflows/reusable-translations.yml
@@ -23,10 +23,6 @@
 #   i18n-script-location (optional, default: 'composer')
 #     Where i18n scripts are run from. Use "npm" if the repo runs i18n via package.json (e.g. @wordpress/scripts).
 #
-#   php-version (optional, default: '8.0')
-#     PHP version used to run Composer and the i18n scripts. Repos whose composer install runs install-time tooling
-#     (e.g. PHP-Scoper) may need a newer version than the default.
-#
 #   po-wrapwidth (optional, default: 77)
 #     Line wrap width when the Python script saves PO files (gettext-style). Only used when the translate script actually writes a file; ignored when po-nowrap is true. Use to match your gettext/xgettext wrap width and reduce formatting-only diffs.
 #
@@ -56,11 +52,6 @@ on:
         required: false
         type: string
         default: 'composer'
-      php-version:
-        description: 'PHP version used to run Composer and the i18n scripts. Repos whose composer install runs install-time tooling (e.g. PHP-Scoper) may need a newer version than the default.'
-        required: false
-        type: string
-        default: '8.0'
       po-wrapwidth:
         description: 'Line wrap width when saving PO files (default 77, match gettext). Ignored when po-nowrap is true.'
         required: false
@@ -194,7 +185,7 @@ jobs:
         id: setup_php
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
-          php-version: "${{ inputs.php-version }}"
+          php-version: "8.3"
 
       # Installs Composer deps so i18n-ci-pre (and i18n-ci-post in a later job) can run.
       - name: Install Composer dependencies
@@ -424,7 +415,7 @@ jobs:
         id: setup_php
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
-          php-version: "${{ inputs.php-version }}"
+          php-version: "8.3"
 
       # Installs Composer deps so i18n-ci-post can run.
       - name: Install Composer dependencies


### PR DESCRIPTION
## What

- `reusable-codecoverage.yml`: new optional `install-php-version` input. When set, composer install runs on that PHP and the job switches back to the matrix PHP for the tests. Default is empty, which keeps the step sequence identical for existing callers.
- `reusable-translations.yml`: PHP 8.0 to 8.3.
- `reusable-plugin-prep-release.yml`: PHP 8.1 to 8.3.

## Why

wp-plugin-bluehost is replacing Strauss with PHP-Scoper (PRESS0-4774), which runs during composer install and requires PHP 8.2+. The plugin still tests down to PHP 7.4 in the codecoverage matrix, so the install there has to happen on a newer PHP than the version under test. The lock file and composer platform config keep the installed tree identical regardless of the installing PHP.

## Consumer impact

- codecoverage: no change unless a repo opts in with the new input.
- translations and prep-release: every caller's composer install now runs on PHP 8.3 instead of 8.0/8.1. This can only break a repo whose committed lock contains a package with an upper-bound PHP constraint and no platform config. Audited all 28 caller repos: 27 pin config.platform.php (7.3.x/7.4.x) so resolution is independent of the runner PHP, and the one unpinned caller (wp-plugin-ai-store) has no package in its lock with an upper bound below 8.3. No caller needs changes.

Jira: PRESS0-4774


Consumer PR that needs this: newfold-labs/wp-plugin-bluehost#1330 (merge this one first).


